### PR TITLE
Bajada de precio a Penetrator

### DIFF
--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -43,7 +43,7 @@
 	name = "Moebius \"Penetrator\" magnetic accelerator barrel"
 	desc = "Uses sympathetic magnetic coiling to increase exit velocity of a metal projectile."
 	icon_state = "Penetrator"
-	price_tag = 300
+	matter = list(MATERIAL_PLASTEEL = 10)
 
 /obj/item/weapon/gun_upgrade/barrel/mag_accel/New()
 	..()
@@ -61,6 +61,7 @@
 	name = "Moebius \"Caster\" magnetic overheat barrel"
 	desc = "Uses magnetic induction to heat the projectile of a weapon. Arguable combat effectiveness, but flashy nonetheless."
 	icon_state = "Caster"
+	matter = list(MATERIAL_PLASTEEL = 10)
 
 /obj/item/weapon/gun_upgrade/barrel/overheat/New()
 	..()

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -43,6 +43,7 @@
 	name = "Moebius \"Penetrator\" magnetic accelerator barrel"
 	desc = "Uses sympathetic magnetic coiling to increase exit velocity of a metal projectile."
 	icon_state = "Penetrator"
+	price_tag = 300
 
 /obj/item/weapon/gun_upgrade/barrel/mag_accel/New()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Se ha sobrescrito la variable por defecto del objeto mag_accel para bajar su precio a la hora de exportarlo, evitando de esta manera que cargo se haga rico abusando de su exportacion.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Previene que la gente de cargo pueda abusar de la venta de Penetrators o por lo menos alivia el problema al hacerlo menos productivo.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Se bajo el precio de exportacion del Pentrator de 500 a 400 creditos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
