### PR TITLE
el mimo ahora es elegible como narrador

### DIFF
--- a/code/game/gamemodes/storytellers/mime.dm
+++ b/code/game/gamemodes/storytellers/mime.dm
@@ -2,8 +2,7 @@
 	config_tag = "mime"
 	name = "The Mime"
 	welcome = "Welcome to CEV Eris! We hope you enjoy your stay!"
-	description = "A storyteller which will not do anything. Designed for admin events."
-	votable = FALSE //admin-only
+	description = "A storyteller which will not do anything."
 
 /datum/storyteller/mime/handle_points() //the mime does not run any events, and points are frozen while the mime is in charge.
 	return


### PR DESCRIPTION
## About The Pull Request
la gente deberia poder elegir como quiere jugar y eris es una tierra de libertad.
## Changelog
:cl:
tweak: habilita al narrador mimo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
