### PR TITLE
Reduce el costo energetico de las linternas y los lentes meson

### DIFF
--- a/code/game/objects/items/devices/lighting/toggleable/flashlight.dm
+++ b/code/game/objects/items/devices/lighting/toggleable/flashlight.dm
@@ -3,7 +3,7 @@
 	dir = WEST
 	suitable_cell = /obj/item/weapon/cell/small
 	rarity_value = 5
-	var/tick_cost = 0.4
+	var/tick_cost = 0.3 //cambiado de 0.4 a 0.3
 
 	var/obj/effect/effect/light/light_spot
 

--- a/code/modules/clothing/glasses/meson.dm
+++ b/code/modules/clothing/glasses/meson.dm
@@ -10,7 +10,7 @@
 	matter = list(MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1)
 	price_tag = 500
 
-	tick_cost = 0.5
+	tick_cost = 0.4//cambiado de 0.5 a 0.4
 
 /obj/item/clothing/glasses/powered/meson/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

porque aunque todo debe tener baterias, el hecho de que duren tan poco tiempo encnedidas es más molesto que otra cosa, puedes encontrar baterias en todo maint pero tner que reemplazarla cada 2 minutos no mola.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: las lintarnas y los meson gastan menos energia por tick
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
